### PR TITLE
Added a new option 'NrtProcessAnyProperty'.

### DIFF
--- a/NetRevisionTask/Tasks/PatchAssemblyInfo.cs
+++ b/NetRevisionTask/Tasks/PatchAssemblyInfo.cs
@@ -93,6 +93,11 @@ namespace NetRevisionTask.Tasks
 		/// </summary>
 		public bool ShowRevision { get; set; }
 
+		/// <summary>
+		/// Gets or sets a value indicating whether all properties are processed.
+		/// </summary>
+		public bool ProcessAnyProperty { get; set; }
+
 		#endregion Properties
 
 		#region Task output properties
@@ -157,7 +162,8 @@ namespace NetRevisionTask.Tasks
 					ResolveInformationalAttribute,
 					RevisionNumberOnly,
 					ResolveCopyright,
-					ShowRevision);
+					ShowRevision,
+					ProcessAnyProperty);
 			}
 			catch (FormatException ex)
 			{

--- a/NetRevisionTask/Tasks/SetVersion.cs
+++ b/NetRevisionTask/Tasks/SetVersion.cs
@@ -70,6 +70,11 @@ namespace NetRevisionTask.Tasks
 		/// </summary>
 		public bool ShowRevision { get; set; }
 
+		/// <summary>
+		/// Gets or sets a value indicating whether all properties are processed.
+		/// </summary>
+		public bool ProcessAnyProperty { get; set; }
+
 		#endregion Properties
 
 		#region Task output properties

--- a/NetRevisionTask/build/Unclassified.NetRevisionTask.targets
+++ b/NetRevisionTask/build/Unclassified.NetRevisionTask.targets
@@ -15,6 +15,7 @@
       <NrtResolveCopyright Condition="'$(NrtResolveCopyright)' == ''">true</NrtResolveCopyright>
       <NrtTagMatch Condition="'$(NrtTagMatch)' == ''">v[0-9]*</NrtTagMatch>
       <NrtRemoveTagV Condition="'$(NrtRemoveTagV)' == ''">true</NrtRemoveTagV>
+      <NrtProcessAnyProperty Condition="'$(NrtProcessAnyProperty)' == ''">false</NrtProcessAnyProperty>
     </PropertyGroup>
   </Target>
 
@@ -31,7 +32,8 @@
       RemoveTagV="$(NrtRemoveTagV)"
       ResolveCopyright="$(NrtResolveCopyright)"
       Copyright="$(Copyright)"
-      ShowRevision="$(NrtShowRevision)">
+      ShowRevision="$(NrtShowRevision)"
+      ProcessAnyProperty="$(NrtProcessAnyProperty)">
       <Output TaskParameter="Version" PropertyName="Version"/>
       <Output TaskParameter="InformationalVersion" PropertyName="InformationalVersion"/>
       <Output TaskParameter="Copyright" PropertyName="Copyright"/>
@@ -66,7 +68,8 @@
       ResolveInformationalAttribute="$(NrtResolveInformationalAttribute)"
       RevisionNumberOnly="$(NrtRevisionNumberOnly)"
       ResolveCopyright="$(NrtResolveCopyright)"
-      ShowRevision="$(NrtShowRevision)">
+      ShowRevision="$(NrtShowRevision)"
+      ProcessAnyProperty="$(NrtProcessAnyProperty)">
       <Output TaskParameter="SourceAssemblyInfo" PropertyName="NrtSourceAssemblyInfo"/>
       <Output TaskParameter="PatchedAssemblyInfo" PropertyName="NrtPatchedAssemblyInfo"/>
     </PatchAssemblyInfo>


### PR DESCRIPTION
Added a new option '**NrtProcessAnyProperty**' to process format strings in any property.
So it's possible to add more defined custom attributes like this:
```
[assembly: AssemblyGitRevision("{CHASH}{!:*}")]
[assembly: AssemblyBuildTime("{b:uymd-} {b:uhms:}")]
```