### PR TITLE
Implemented resolving AssemblyMetadata, build configuration format strings and build error on dirty repo

### DIFF
--- a/NetRevisionTask/Api.cs
+++ b/NetRevisionTask/Api.cs
@@ -13,13 +13,15 @@ namespace NetRevisionTask
 			string revisionFormat = null,
 			string tagMatch = "v[0-9]*",
 			bool removeTagV = true,
-			string copyright = null)
+			string copyright = null,
+			string configurationName = null)
 		{
 			if (string.IsNullOrEmpty(projectDir))
 				projectDir = Directory.GetCurrentDirectory();
 			var logger = new ConsoleLogger();
 
-			var result = Common.GetVersion(projectDir, requiredVcs, revisionFormat, tagMatch, removeTagV, copyright ?? "", logger, true);
+			var result = Common.GetVersion(projectDir, requiredVcs, revisionFormat, tagMatch, removeTagV, copyright ?? "", logger, true, 
+				configurationName);
 			if (!result.success)
 			{
 				return null;
@@ -33,13 +35,15 @@ namespace NetRevisionTask
 			string revisionFormat = null,
 			string tagMatch = "v[0-9]*",
 			bool removeTagV = true,
-			string copyright = null)
+			string copyright = null,
+			string configurationName = null)
 		{
 			if (string.IsNullOrEmpty(projectDir))
 				projectDir = Directory.GetCurrentDirectory();
 			var logger = new ConsoleLogger();
 
-			var result = Common.GetVersion(projectDir, requiredVcs, revisionFormat, tagMatch, removeTagV, copyright ?? "", logger, true);
+			var result = Common.GetVersion(projectDir, requiredVcs, revisionFormat, tagMatch, removeTagV, copyright ?? "", logger, true,
+				configurationName);
 			if (!result.success)
 			{
 				return null;

--- a/NetRevisionTask/Api.cs
+++ b/NetRevisionTask/Api.cs
@@ -14,14 +14,15 @@ namespace NetRevisionTask
 			string tagMatch = "v[0-9]*",
 			bool removeTagV = true,
 			string copyright = null,
-			string configurationName = null)
+			string configurationName = null,
+			string errorOnModifiedRepoPattern = null)
 		{
 			if (string.IsNullOrEmpty(projectDir))
 				projectDir = Directory.GetCurrentDirectory();
 			var logger = new ConsoleLogger();
 
 			var result = Common.GetVersion(projectDir, requiredVcs, revisionFormat, tagMatch, removeTagV, copyright ?? "", logger, true, 
-				configurationName);
+				configurationName, errorOnModifiedRepoPattern);
 			if (!result.success)
 			{
 				return null;
@@ -36,14 +37,15 @@ namespace NetRevisionTask
 			string tagMatch = "v[0-9]*",
 			bool removeTagV = true,
 			string copyright = null,
-			string configurationName = null)
+			string configurationName = null,
+			string errorOnModifiedRepoPattern = null)
 		{
 			if (string.IsNullOrEmpty(projectDir))
 				projectDir = Directory.GetCurrentDirectory();
 			var logger = new ConsoleLogger();
 
 			var result = Common.GetVersion(projectDir, requiredVcs, revisionFormat, tagMatch, removeTagV, copyright ?? "", logger, true,
-				configurationName);
+				configurationName, errorOnModifiedRepoPattern);
 			if (!result.success)
 			{
 				return null;

--- a/NetRevisionTask/AssemblyInfoHelper.cs
+++ b/NetRevisionTask/AssemblyInfoHelper.cs
@@ -78,6 +78,7 @@ namespace NetRevisionTask
 		/// <param name="revOnly">Indicates whether only the last number is replaced by the revision number.</param>
 		/// <param name="copyrightAttribute">Indicates whether the copyright year is replaced.</param>
 		/// <param name="echo">Indicates whether the final informational version string is displayed.</param>
+		/// <param name="metadataAttribute">Indicates whether the AssemblyMetadata attribute is processed.</param>
 		/// <returns>The name of the patched AssemblyInfo file.</returns>
 		public string PatchFile(
 			string patchedFileDir,
@@ -87,7 +88,8 @@ namespace NetRevisionTask
 			bool informationalAttribute,
 			bool revOnly,
 			bool copyrightAttribute,
-			bool echo)
+			bool echo,
+			bool metadataAttribute)
 		{
 			logger?.Trace($@"Patching file ""{fileName}""...");
 			ReadFileLines(FullFileName);
@@ -111,7 +113,7 @@ namespace NetRevisionTask
 			}
 
 			// Process all lines in the file
-			ResolveAllLines(rf, simpleAttributes, informationalAttribute, revOnly, copyrightAttribute, echo);
+			ResolveAllLines(rf, simpleAttributes, informationalAttribute, revOnly, copyrightAttribute, echo, metadataAttribute);
 
 			// Write all lines to the file
 			string patchedFileName = Path.Combine(patchedFileDir, "Nrt" + Path.GetFileName(fileName));
@@ -250,7 +252,8 @@ namespace NetRevisionTask
 		/// <param name="revOnly">Indicates whether only the last number is replaced by the revision number.</param>
 		/// <param name="copyrightAttribute">Indicates whether the copyright year is replaced.</param>
 		/// <param name="echo">Indicates whether the final informational version string is displayed.</param>
-		private void ResolveAllLines(RevisionFormatter rf, bool simpleAttributes, bool informationalAttribute, bool revOnly, bool copyrightAttribute, bool echo)
+		/// <param name="metadataAttribute">Indicates whether the AssemblyMetadata attribute is processed.</param>
+		private void ResolveAllLines(RevisionFormatter rf, bool simpleAttributes, bool informationalAttribute, bool revOnly, bool copyrightAttribute, bool echo, bool metadataAttribute)
 		{
 			// Preparing a truncated dotted-numeric version if we may need it
 			string truncVersion = null;
@@ -383,6 +386,23 @@ namespace NetRevisionTask
 						lines[i] = match.Groups[1].Value + copyrightText + match.Groups[3].Value;
 						logger?.Success("Found AssemblyCopyright attribute.");
 						logger?.Trace($@"  Replaced ""{match.Groups[2].Value}"" with ""{copyrightText}"".");
+					}
+				}
+
+				if (metadataAttribute)
+				{
+					// Replace the value part of AssemblyMetadata with the resolved string of what
+					// was already there. Format: [assembly: AssemblyMetadata("Key", "Value")]
+					match = Regex.Match(
+						lines[i],
+						@"^(\s*\" + attrStart + @"\s*assembly\s*:\s*AssemblyMetadata\s*\(\s*"")(.*?)(""\s*,\s*"")(.*?)(""\s*\)\s*\" + attrEnd + @".*)$",
+						RegexOptions.IgnoreCase);
+					if (match.Success)
+					{
+						string metadataText = rf.Resolve(match.Groups[4].Value);
+						lines[i] = match.Groups[1].Value + match.Groups[2].Value + match.Groups[3].Value + metadataText + match.Groups[5].Value;
+						logger?.Success("Found AssemblyMetadata attribute.");
+						logger?.Trace($@"  Replaced [{match.Groups[2].Value}] => ""{match.Groups[4].Value}"" with ""{metadataText}"".");
 					}
 				}
 			}

--- a/NetRevisionTask/Common.cs
+++ b/NetRevisionTask/Common.cs
@@ -26,7 +26,7 @@ namespace NetRevisionTask
 				revisionFormat = data.GetDefaultRevisionFormat(logger);
 			}
 
-			var rf = new RevisionFormatter { RevisionData = data, RemoveTagV = removeTagV };
+			var rf = new RevisionFormatter { RevisionData = data, RemoveTagV = removeTagV, BuildTime = DateTimeOffset.Now };
 			try
 			{
 				return (true, rf.ResolveShort(revisionFormat), rf.Resolve(revisionFormat), rf.Resolve(copyright));

--- a/NetRevisionTask/Common.cs
+++ b/NetRevisionTask/Common.cs
@@ -8,7 +8,8 @@ namespace NetRevisionTask
 	internal class Common
 	{
 		public static (bool success, string version, string informationalVersion, string copyright)
-			GetVersion(string projectDir, string requiredVcs, string revisionFormat, string tagMatch, bool removeTagV, string copyright, ILogger logger, bool warnOnMissing)
+			GetVersion(string projectDir, string requiredVcs, string revisionFormat, string tagMatch, bool removeTagV, string copyright, ILogger logger, bool warnOnMissing,
+				string configurationName)
 		{
 			// Analyse working directory
 			RevisionData data = ProcessDirectory(projectDir, requiredVcs, tagMatch, logger);
@@ -26,7 +27,7 @@ namespace NetRevisionTask
 				revisionFormat = data.GetDefaultRevisionFormat(logger);
 			}
 
-			var rf = new RevisionFormatter { RevisionData = data, RemoveTagV = removeTagV, BuildTime = DateTimeOffset.Now };
+			var rf = new RevisionFormatter { RevisionData = data, RemoveTagV = removeTagV, BuildTime = DateTimeOffset.Now, ConfigurationName = configurationName };
 			try
 			{
 				return (true, rf.ResolveShort(revisionFormat), rf.Resolve(revisionFormat), rf.Resolve(copyright));

--- a/NetRevisionTask/NetRevisionTask.csproj
+++ b/NetRevisionTask/NetRevisionTask.csproj
@@ -8,7 +8,7 @@
     <!-- Change the default location where NuGet will put the build output -->
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
 
-    <VersionPrefix>0.4</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <!--VersionSuffix>beta</VersionSuffix-->
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/NetRevisionTask/NetRevisionTask.csproj
+++ b/NetRevisionTask/NetRevisionTask.csproj
@@ -8,7 +8,7 @@
     <!-- Change the default location where NuGet will put the build output -->
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
 
-    <VersionPrefix>0.4.1</VersionPrefix>
+    <VersionPrefix>0.4.2</VersionPrefix>
     <!--VersionSuffix>beta</VersionSuffix-->
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/NetRevisionTask/NetRevisionTask.csproj
+++ b/NetRevisionTask/NetRevisionTask.csproj
@@ -8,7 +8,7 @@
     <!-- Change the default location where NuGet will put the build output -->
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
 
-    <VersionPrefix>0.3</VersionPrefix>
+    <VersionPrefix>0.4</VersionPrefix>
     <!--VersionSuffix>beta</VersionSuffix-->
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/NetRevisionTask/RevisionFormatter.cs
+++ b/NetRevisionTask/RevisionFormatter.cs
@@ -154,8 +154,8 @@ namespace NetRevisionTask
 			// Build Configuration
 			format = format.Replace("{bconf}", ConfigurationName);
 			format = format.Replace("{BCONF}", ConfigurationName.ToUpperInvariant());
-			format = Regex.Replace(format, @"\{bconf:(.*?):(.+?)\}", m => ConfigurationName != m.Groups[2].Value ? m.Groups[1].Value + ConfigurationName : "");
-			format = Regex.Replace(format, @"\{BCONF:(.*?):(.+?)\}", m => ConfigurationName != m.Groups[2].Value ? m.Groups[1].Value + ConfigurationName.ToUpperInvariant() : "");
+			format = Regex.Replace(format, @"\{bconf:(.*?):(.+?)\}", m => !Regex.IsMatch(ConfigurationName, $@"^{m.Groups[2].Value}$", RegexOptions.IgnoreCase) ? m.Groups[1].Value + ConfigurationName : "");
+			format = Regex.Replace(format, @"\{BCONF:(.*?):(.+?)\}", m => !Regex.IsMatch(ConfigurationName, $@"^{m.Groups[2].Value}$", RegexOptions.IgnoreCase) ? m.Groups[1].Value + ConfigurationName.ToUpperInvariant() : "");
 
 			// Return revision ID
 			return format;

--- a/NetRevisionTask/RevisionFormatter.cs
+++ b/NetRevisionTask/RevisionFormatter.cs
@@ -157,6 +157,10 @@ namespace NetRevisionTask
 			format = Regex.Replace(format, @"\{copyright:([0-9]+?)-?\}", m => (m.Groups[1].Value != copyright ? m.Groups[1].Value + "–" : "") + copyright);
 
 			// Build Configuration
+			if (ConfigurationName == null)
+            {
+				ConfigurationName = string.Empty;
+			}
 			format = format.Replace("{bconf}", ConfigurationName);
 			format = format.Replace("{BCONF}", ConfigurationName.ToUpperInvariant());
 			format = Regex.Replace(format, @"\{bconf:(.*?):(.+?)\}", m => !Regex.IsMatch(ConfigurationName, $@"^{m.Groups[2].Value}$", RegexOptions.IgnoreCase) ? m.Groups[1].Value + ConfigurationName : "");

--- a/NetRevisionTask/RevisionFormatter.cs
+++ b/NetRevisionTask/RevisionFormatter.cs
@@ -158,7 +158,7 @@ namespace NetRevisionTask
 
 			// Build Configuration
 			if (ConfigurationName == null)
-            {
+			{
 				ConfigurationName = string.Empty;
 			}
 			format = format.Replace("{bconf}", ConfigurationName);

--- a/NetRevisionTask/RevisionFormatter.cs
+++ b/NetRevisionTask/RevisionFormatter.cs
@@ -111,6 +111,11 @@ namespace NetRevisionTask
 			}
 
 			string tagName = RevisionData.Tag;
+			if (string.IsNullOrEmpty(tagName))
+			{
+				// default value when no tag exists in repository
+				tagName = "v0.0.0.0";
+			}
 			if (RemoveTagV && Regex.IsMatch(tagName, "^v[0-9]"))
 			{
 				tagName = tagName.Substring(1);

--- a/NetRevisionTask/RevisionFormatter.cs
+++ b/NetRevisionTask/RevisionFormatter.cs
@@ -58,6 +58,11 @@ namespace NetRevisionTask
 			set => buildTime = value;
 		}
 
+		/// <summary>
+		/// Gets the value of the build configuration name.
+		/// </summary>
+		public string ConfigurationName { get; set; }
+
 		#endregion Data properties
 
 		#region Format resolving
@@ -145,6 +150,12 @@ namespace NetRevisionTask
 			}
 			format = format.Replace("{copyright}", copyright);
 			format = Regex.Replace(format, @"\{copyright:([0-9]+?)-?\}", m => (m.Groups[1].Value != copyright ? m.Groups[1].Value + "–" : "") + copyright);
+
+			// Build Configuration
+			format = format.Replace("{bconf}", ConfigurationName);
+			format = format.Replace("{BCONF}", ConfigurationName.ToUpperInvariant());
+			format = Regex.Replace(format, @"\{bconf:(.*?):(.+?)\}", m => ConfigurationName != m.Groups[2].Value ? m.Groups[1].Value + ConfigurationName : "");
+			format = Regex.Replace(format, @"\{BCONF:(.*?):(.+?)\}", m => ConfigurationName != m.Groups[2].Value ? m.Groups[1].Value + ConfigurationName.ToUpperInvariant() : "");
 
 			// Return revision ID
 			return format;

--- a/NetRevisionTask/RevisionFormatter.cs
+++ b/NetRevisionTask/RevisionFormatter.cs
@@ -11,7 +11,7 @@ namespace NetRevisionTask
 	{
 		#region Static data
 
-		private static readonly DateTimeOffset buildTime = DateTimeOffset.Now;
+		private static DateTimeOffset buildTime = DateTimeOffset.Now;
 
 		/// <summary>
 		/// Alphabet for the base-28 encoding. This uses the digits 0–9 and all characters a–z that
@@ -50,9 +50,13 @@ namespace NetRevisionTask
 		public bool RemoveTagV { get; set; }
 
 		/// <summary>
-		/// Gets the build time.
+		/// Gets or sets the build time.
 		/// </summary>
-		public DateTimeOffset BuildTime => buildTime;
+		public DateTimeOffset BuildTime
+		{
+			get => buildTime;
+			set => buildTime = value;
+		}
 
 		#endregion Data properties
 

--- a/NetRevisionTask/Tasks/PatchAssemblyInfo.cs
+++ b/NetRevisionTask/Tasks/PatchAssemblyInfo.cs
@@ -98,6 +98,11 @@ namespace NetRevisionTask.Tasks
 		/// </summary>
 		public bool ResolveMetadata { get; set; }
 
+		/// <summary>
+		/// Gets or sets the value of the build configuration name.
+		/// </summary>
+		public string ConfigurationName { get; set; }
+
 		#endregion Properties
 
 		#region Task output properties
@@ -149,7 +154,8 @@ namespace NetRevisionTask.Tasks
 				RevisionFormat = data.GetDefaultRevisionFormat(logger);
 			}
 
-			var rf = new RevisionFormatter { RevisionData = data, RemoveTagV = RemoveTagV };
+			var rf = new RevisionFormatter { RevisionData = data, RemoveTagV = RemoveTagV,
+				ConfigurationName = ConfigurationName };
 			try
 			{
 				var aih = new AssemblyInfoHelper(ProjectDir, true, logger);

--- a/NetRevisionTask/Tasks/PatchAssemblyInfo.cs
+++ b/NetRevisionTask/Tasks/PatchAssemblyInfo.cs
@@ -103,6 +103,12 @@ namespace NetRevisionTask.Tasks
 		/// </summary>
 		public string ConfigurationName { get; set; }
 
+		/// <summary>
+		/// Gets or sets the value of the build configuration RegEx pattern that triggers an error
+		/// on match if the repository is modified.
+		/// </summary>
+		public string ErrorOnModifiedRepoPattern { get; set; }
+
 		#endregion Properties
 
 		#region Task output properties
@@ -152,6 +158,12 @@ namespace NetRevisionTask.Tasks
 			if (string.IsNullOrEmpty(RevisionFormat))
 			{
 				RevisionFormat = data.GetDefaultRevisionFormat(logger);
+			}
+
+			// check whether a modified repository triggers a build error
+			if (Common.TriggerErrorIfRepoModified(logger, data, ErrorOnModifiedRepoPattern, ConfigurationName))
+			{
+				return false;
 			}
 
 			var rf = new RevisionFormatter { RevisionData = data, RemoveTagV = RemoveTagV,

--- a/NetRevisionTask/Tasks/PatchAssemblyInfo.cs
+++ b/NetRevisionTask/Tasks/PatchAssemblyInfo.cs
@@ -93,6 +93,11 @@ namespace NetRevisionTask.Tasks
 		/// </summary>
 		public bool ShowRevision { get; set; }
 
+		/// <summary>
+		/// Gets or sets a value indicating whether the AssemblyMetadata attribute is processed.
+		/// </summary>
+		public bool ResolveMetadata { get; set; }
+
 		#endregion Properties
 
 		#region Task output properties
@@ -157,7 +162,8 @@ namespace NetRevisionTask.Tasks
 					ResolveInformationalAttribute,
 					RevisionNumberOnly,
 					ResolveCopyright,
-					ShowRevision);
+					ShowRevision,
+					ResolveMetadata);
 			}
 			catch (FormatException ex)
 			{

--- a/NetRevisionTask/Tasks/SetVersion.cs
+++ b/NetRevisionTask/Tasks/SetVersion.cs
@@ -74,6 +74,12 @@ namespace NetRevisionTask.Tasks
 		/// </summary>
 		public string ConfigurationName { get; set; }
 
+		/// <summary>
+		/// Gets or sets the value of the build configuration RegEx pattern that triggers an error
+		/// on match if the repository is modified.
+		/// </summary>
+		public string ErrorOnModifiedRepoPattern { get; set; }
+
 		#endregion Properties
 
 		#region Task output properties
@@ -116,7 +122,7 @@ namespace NetRevisionTask.Tasks
 			logger.Trace($"NetRevisionTask: SetVersion ({targetFramework})");
 
 			var result = Common.GetVersion(ProjectDir, RequiredVcs, RevisionFormat, TagMatch, RemoveTagV, Copyright ?? "", logger, !GenerateAssemblyInfo,
-				ConfigurationName);
+				ConfigurationName, ErrorOnModifiedRepoPattern);
 			if (!result.success)
 			{
 				return false;

--- a/NetRevisionTask/Tasks/SetVersion.cs
+++ b/NetRevisionTask/Tasks/SetVersion.cs
@@ -69,6 +69,11 @@ namespace NetRevisionTask.Tasks
 		/// </summary>
 		public bool ShowRevision { get; set; }
 
+		/// <summary>
+		/// Gets the value of the build configuration name.
+		/// </summary>
+		public string ConfigurationName { get; set; }
+
 		#endregion Properties
 
 		#region Task output properties
@@ -110,7 +115,8 @@ namespace NetRevisionTask.Tasks
 			logger = new TaskLogger(Log);
 			logger.Trace($"NetRevisionTask: SetVersion ({targetFramework})");
 
-			var result = Common.GetVersion(ProjectDir, RequiredVcs, RevisionFormat, TagMatch, RemoveTagV, Copyright ?? "", logger, !GenerateAssemblyInfo);
+			var result = Common.GetVersion(ProjectDir, RequiredVcs, RevisionFormat, TagMatch, RemoveTagV, Copyright ?? "", logger, !GenerateAssemblyInfo,
+				ConfigurationName);
 			if (!result.success)
 			{
 				return false;

--- a/NetRevisionTask/build/Unclassified.NetRevisionTask.targets
+++ b/NetRevisionTask/build/Unclassified.NetRevisionTask.targets
@@ -33,7 +33,8 @@
       ResolveCopyright="$(NrtResolveCopyright)"
       Copyright="$(Copyright)"
       ShowRevision="$(NrtShowRevision)"
-      ConfigurationName="$(ConfigurationName)">
+      ConfigurationName="$(ConfigurationName)"
+      ErrorOnModifiedRepoPattern="$(NrtErrorOnModifiedRepoPattern)">
       <Output TaskParameter="Version" PropertyName="Version"/>
       <Output TaskParameter="InformationalVersion" PropertyName="InformationalVersion"/>
       <Output TaskParameter="Copyright" PropertyName="Copyright"/>
@@ -70,7 +71,8 @@
       ResolveCopyright="$(NrtResolveCopyright)"
       ShowRevision="$(NrtShowRevision)"
       ResolveMetadata="$(NrtResolveMetadata)"
-      ConfigurationName="$(ConfigurationName)">
+      ConfigurationName="$(ConfigurationName)"
+      ErrorOnModifiedRepoPattern="$(NrtErrorOnModifiedRepoPattern)">
       <Output TaskParameter="SourceAssemblyInfo" PropertyName="NrtSourceAssemblyInfo"/>
       <Output TaskParameter="PatchedAssemblyInfo" PropertyName="NrtPatchedAssemblyInfo"/>
     </PatchAssemblyInfo>

--- a/NetRevisionTask/build/Unclassified.NetRevisionTask.targets
+++ b/NetRevisionTask/build/Unclassified.NetRevisionTask.targets
@@ -13,6 +13,7 @@
       <NrtResolveSimpleAttributes Condition="'$(NrtResolveSimpleAttributes)' == ''">true</NrtResolveSimpleAttributes>
       <NrtResolveInformationalAttribute Condition="'$(NrtResolveInformationalAttribute)' == ''">true</NrtResolveInformationalAttribute>
       <NrtResolveCopyright Condition="'$(NrtResolveCopyright)' == ''">true</NrtResolveCopyright>
+      <NrtResolveMetadata Condition="'$(NrtResolveMetadata)' == ''">true</NrtResolveMetadata>
       <NrtTagMatch Condition="'$(NrtTagMatch)' == ''">v[0-9]*</NrtTagMatch>
       <NrtRemoveTagV Condition="'$(NrtRemoveTagV)' == ''">true</NrtRemoveTagV>
     </PropertyGroup>
@@ -66,7 +67,8 @@
       ResolveInformationalAttribute="$(NrtResolveInformationalAttribute)"
       RevisionNumberOnly="$(NrtRevisionNumberOnly)"
       ResolveCopyright="$(NrtResolveCopyright)"
-      ShowRevision="$(NrtShowRevision)">
+      ShowRevision="$(NrtShowRevision)"
+      ResolveMetadata="$(NrtResolveMetadata)">
       <Output TaskParameter="SourceAssemblyInfo" PropertyName="NrtSourceAssemblyInfo"/>
       <Output TaskParameter="PatchedAssemblyInfo" PropertyName="NrtPatchedAssemblyInfo"/>
     </PatchAssemblyInfo>

--- a/NetRevisionTask/build/Unclassified.NetRevisionTask.targets
+++ b/NetRevisionTask/build/Unclassified.NetRevisionTask.targets
@@ -32,7 +32,8 @@
       RemoveTagV="$(NrtRemoveTagV)"
       ResolveCopyright="$(NrtResolveCopyright)"
       Copyright="$(Copyright)"
-      ShowRevision="$(NrtShowRevision)">
+      ShowRevision="$(NrtShowRevision)"
+      ConfigurationName="$(ConfigurationName)">
       <Output TaskParameter="Version" PropertyName="Version"/>
       <Output TaskParameter="InformationalVersion" PropertyName="InformationalVersion"/>
       <Output TaskParameter="Copyright" PropertyName="Copyright"/>
@@ -68,7 +69,8 @@
       RevisionNumberOnly="$(NrtRevisionNumberOnly)"
       ResolveCopyright="$(NrtResolveCopyright)"
       ShowRevision="$(NrtShowRevision)"
-      ResolveMetadata="$(NrtResolveMetadata)">
+      ResolveMetadata="$(NrtResolveMetadata)"
+      ConfigurationName="$(ConfigurationName)">
       <Output TaskParameter="SourceAssemblyInfo" PropertyName="NrtSourceAssemblyInfo"/>
       <Output TaskParameter="PatchedAssemblyInfo" PropertyName="NrtPatchedAssemblyInfo"/>
     </PatchAssemblyInfo>

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ The following data field placeholders are supported:
 
 **`{copyright:<first>-}`**: Abbreviation for the copyright year range, starting at `<first>`. The following dash is optional but recommended for clearer understanding.
 
+**`{bconf}`**: Build configuration.
+
+**`{BCONF}`**: Build configuration, in upper case.
+
+**`{bconf:<sep>:<ref>}`, `{BCONF:<sep>:<ref>}`**: Build configuration, if not `<ref>` or empty, separated by `<sep>`, otherwise empty.
+
 Schemes convert a commit or build time to a compact string representation. They can be used to assign incrementing versions if no revision number is provided by the VCS. First, select from the build, commit or authoring time with `{b:…}`, `{c:…}` or `{a:…}`. This is followed by the scheme name. There are 4 types of schemes.
 
 The following time schemes are supported:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Specifies whether the value component of the `AssemblyMetadata` (`AssemblyMetada
 
 **NrtErrorOnModifiedRepoPattern**: string, default: “”.
 
-Specifies a case-insensitive Regex pattern string matching the build configuration string to trigger a build error if the repository contains modifications. If the string is empty, the functionality is disabled.
+Specifies a case-insensitive RegEx pattern string matching the build configuration string to trigger a build error if the repository contains modifications. If the string is empty, the functionality is disabled.
 
 ### Revision format
 
@@ -180,7 +180,7 @@ The following data field placeholders are supported:
 
 **`{BCONF}`**: Build configuration, in upper case.
 
-**`{bconf:<sep>:<ref>}`, `{BCONF:<sep>:<ref>}`**: Build configuration, if not `<ref>` or empty, separated by `<sep>`, otherwise empty.
+**`{bconf:<sep>:<ref>}`, `{BCONF:<sep>:<ref>}`**: Build configuration, if not matching case-insensitive RegEx `<ref>` pattern, separated by `<sep>`, otherwise empty.
 
 Schemes convert a commit or build time to a compact string representation. They can be used to assign incrementing versions if no revision number is provided by the VCS. First, select from the build, commit or authoring time with `{b:…}`, `{c:…}` or `{a:…}`. This is followed by the scheme name. There are 4 types of schemes.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Example:
       <NrtRequiredVcs>git</NrtRequiredVcs>
       <NrtShowRevision>true</NrtShowRevision>
       <NrtResolveMetadata>true</NrtResolveMetadata>
+      <NrtErrorOnModifiedRepoPattern>.*Release.*</NrtErrorOnModifiedRepoPattern>
     </PropertyGroup>
 
 The following MSBuild properties are supported:
@@ -108,6 +109,10 @@ Specifies whether the determined revision ID is printed during the build with hi
 **NrtResolveMetadata**: boolean, default: true.
 
 Specifies whether the value component of the `AssemblyMetadata` (`AssemblyMetadataAttribute`) is resolved.
+
+**NrtErrorOnModifiedRepoPattern**: string, default: “”.
+
+Specifies a case-insensitive Regex pattern string matching the build configuration string to trigger a build error if the repository contains modifications. If the string is empty, the functionality is disabled.
 
 ### Revision format
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Example:
       <NrtRemoveTagV>true</NrtRemoveTagV>
       <NrtRequiredVcs>git</NrtRequiredVcs>
       <NrtShowRevision>true</NrtShowRevision>
+      <NrtResolveMetadata>true</NrtResolveMetadata>
     </PropertyGroup>
 
 The following MSBuild properties are supported:
@@ -103,6 +104,10 @@ Specifies the name of the VCS that is expected to be found in the project direct
 **NrtShowRevision**: boolean, default: false.
 
 Specifies whether the determined revision ID is printed during the build with higher importance than normal, so it can be seen more easily. When patching the AssemblyInfo file, it is also displayed to the console.
+
+**NrtResolveMetadata**: boolean, default: true.
+
+Specifies whether the value component of the `AssemblyMetadata` (`AssemblyMetadataAttribute`) is resolved.
 
 ### Revision format
 


### PR DESCRIPTION
Hello Yves,

I have extended Net Revision Task with the following changes:
- Implemented resolving of `AssemblyMetadata` attributes value format strings (enabled by default)
- BuildTime is updated if `GetVersion()` is called (otherwise the build time stays constant until the Solution is reloaded)
- Added `{bconf}`, `{BCONF}` and `{bconf:<sep>:<ref>}` format strings to resolve build configuration names
- Implemented a RegEx match pattern to trigger a build error if the repository contains modifications

Please let me know if you don't agree with the changes or see potential for optimizations.

Best regards,
Mark