### PR TITLE
replaced Unicode long hyphen for copyright date with ASCII hyphen

### DIFF
--- a/NetRevisionTask/RevisionFormatter.cs
+++ b/NetRevisionTask/RevisionFormatter.cs
@@ -140,7 +140,7 @@ namespace NetRevisionTask
 				copyright = RevisionData.CommitTime.Year.ToString();
 			}
 			format = format.Replace("{copyright}", copyright);
-			format = Regex.Replace(format, @"\{copyright:([0-9]+?)-?\}", m => (m.Groups[1].Value != copyright ? m.Groups[1].Value + "–" : "") + copyright);
+			format = Regex.Replace(format, @"\{copyright:([0-9]+?)-?\}", m => (m.Groups[1].Value != copyright ? m.Groups[1].Value + "-" : "") + copyright);
 
 			// Return revision ID
 			return format;


### PR DESCRIPTION
When replacing the copyright year, a standard ASCII hyphen ```0x2D``` shall be used instead of the Unicode character sequence ```0xE2 0x80 0x93``` to avoid issues when working with plain ASCII file formats.