### PR TITLE
Fix: adapt GitProvider to detect Git worktrees also.

### DIFF
--- a/NetRevisionTask/VcsProviders/GitProvider.cs
+++ b/NetRevisionTask/VcsProviders/GitProvider.cs
@@ -71,6 +71,12 @@ namespace NetRevisionTask.VcsProviders
 					rootPath = path;
 					return true;
 				}
+				if (File.Exists(Path.Combine(path, ".git")))
+				{
+					Logger?.Success($"  Found {path} [uses worktree]");
+					rootPath = path;
+					return true;
+				}
 				path = Path.GetDirectoryName(path);
 			}
 			while (!string.IsNullOrEmpty(path));


### PR DESCRIPTION
I am currently working with Git Worktrees on a Win64 platform. Worktrees are managed by git as "flat files containing a link description" to the original file or directory. 
**Idea**:
To be able to handle such situation, the method _CheckDirectory(string path, out string rootPath)_ has to be extended to detect ".git" files also.