### PR TITLE
Added Nrt Project Directory Property

### DIFF
--- a/NetRevisionTask/NetRevisionTask.csproj
+++ b/NetRevisionTask/NetRevisionTask.csproj
@@ -8,7 +8,7 @@
     <!-- Change the default location where NuGet will put the build output -->
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
 
-    <VersionPrefix>0.4.2</VersionPrefix>
+    <VersionPrefix>0.4.3</VersionPrefix>
     <!--VersionSuffix>beta</VersionSuffix-->
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/NetRevisionTask/build/Unclassified.NetRevisionTask.targets
+++ b/NetRevisionTask/build/Unclassified.NetRevisionTask.targets
@@ -15,6 +15,7 @@
       <NrtResolveCopyright Condition="'$(NrtResolveCopyright)' == ''">true</NrtResolveCopyright>
       <NrtTagMatch Condition="'$(NrtTagMatch)' == ''">v[0-9]*</NrtTagMatch>
       <NrtRemoveTagV Condition="'$(NrtRemoveTagV)' == ''">true</NrtRemoveTagV>
+      <NrtProjectDir Condition="'$(NrtProjectDir)' == ''">$(MSBuildProjectDirectory)</NrtProjectDir>
     </PropertyGroup>
   </Target>
 
@@ -27,7 +28,7 @@
   -->
   <Target Name="NrtSetVersion" BeforeTargets="GenerateAdditionalSources">
     <SetVersion
-      ProjectDir="$(MSBuildProjectDirectory)"
+      ProjectDir="$(NrtProjectDir)"
       GenerateAssemblyInfo="$(GenerateAssemblyInfo)"
       NuGetPackOutput="@(NuGetPackOutput)"
       RevisionFormat="$(NrtRevisionFormat)"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Example:
       <NrtRemoveTagV>true</NrtRemoveTagV>
       <NrtRequiredVcs>git</NrtRequiredVcs>
       <NrtShowRevision>true</NrtShowRevision>
+      <NrtProjectDirectory>$(MSBuildProjectDirectory)</NrtProjectDirectory>
     </PropertyGroup>
 
 The following MSBuild properties are supported:
@@ -115,6 +116,10 @@ Specifies the name of the VCS that is expected to be found in the project direct
 **NrtShowRevision**: boolean, default: false.
 
 Specifies whether the determined revision ID is printed during the build with higher importance than normal, so it can be seen more easily. When patching the AssemblyInfo file, it is also displayed to the console.
+
+**NrtProjectDirectory**: string, default: $(MSBuildProjectDirectory).
+
+Sets the directory, where NRT starts searching for the VCS files. This is helpful if NRT is added to a project, that is a submodule of another repository and should observe the parent repository.
 
 ### Revision format
 


### PR DESCRIPTION
- I needed this to use -dirty Branch etc. for the parent repository of the repo, the project and NuGet are part of.
- This is just a minor change, that allows for setting the directory where the search for in my case the .git dir starts.