### PR TITLE
Get clean version tag name

### DIFF
--- a/NetRevisionTask/RevisionFormatter.cs
+++ b/NetRevisionTask/RevisionFormatter.cs
@@ -102,8 +102,15 @@ namespace NetRevisionTask
 			}
 
 			string tagName = RevisionData.Tag;
-			if (RemoveTagV && Regex.IsMatch(tagName, "^v[0-9]"))
+			// This detects any pattern of v1 to v1.2.3-foo.
+			// It is way more complex, but can also trim tags like "project-one/v1.2.3-alpha2".
+			// These tag-types are often used by mono-repositories.
+			string versionPattern = @"v([0-9]+(?:\.[0-9]+(?:\.[0-9]+)?)?)(?:-(.+))?$";
+			if (RemoveTagV && Regex.IsMatch(tagName, versionPattern))
 			{
+				// Replace anything around the pattern.
+				tagName = tagName.Replace(Regex.Replace(tagName, versionPattern, ""), "");
+				// Remove the "v" at the start.
 				tagName = tagName.Substring(1);
 			}
 			format = format.Replace("{semvertag}", GetSemVerTagSpec(tagName));


### PR DESCRIPTION
I got to work on a repository with multiple versions for different projects within that repository (mono repository).

The tags are named with folders
- project1/v1.0.0
- project1/v1.2.3
- project2/v0.1.0
- project2/v0.5.1

The directory.build.props have their `<NrtTagMatch>project1/v[0-9]*</NrtTagMatch>` and `<NrtTagMatch>project2/v[0-9]*</NrtTagMatch>` set properly.

to get clean versions, the change is required.